### PR TITLE
Bugfix: login in fixed time

### DIFF
--- a/modules/apis/user/src/main/scala/phms/api/user/UserAPI.scala
+++ b/modules/apis/user/src/main/scala/phms/api/user/UserAPI.scala
@@ -33,7 +33,7 @@ object UserAPI {
     userAlgebra:          UserAlgebra[F],
     userAuthAlgebra:      UserAuthAlgebra[F],
     userAccountOrganizer: UserAccountOrganizer[F],
-  )(implicit F:           Concurrent[F], D: Defer[F], temporal: Temporal[F]): Resource[F, UserAPI[F]] =
+  )(implicit temporal:    Temporal[F], D: Defer[F]): Resource[F, UserAPI[F]] =
     for {
       userRoutes        <- Resource.pure[F, UserRoutes[F]](new UserRoutes[F](userAlgebra))
       userLoginRoutes   <- Resource.pure[F, UserLoginRoutes[F]](new UserLoginRoutes[F](userAuthAlgebra))

--- a/modules/apis/user/src/main/scala/phms/api/user/UserAPI.scala
+++ b/modules/apis/user/src/main/scala/phms/api/user/UserAPI.scala
@@ -33,7 +33,7 @@ object UserAPI {
     userAlgebra:          UserAlgebra[F],
     userAuthAlgebra:      UserAuthAlgebra[F],
     userAccountOrganizer: UserAccountOrganizer[F],
-  )(implicit F:           Concurrent[F], D: Defer[F]): Resource[F, UserAPI[F]] =
+  )(implicit F:           Concurrent[F], D: Defer[F], temporal: Temporal[F]): Resource[F, UserAPI[F]] =
     for {
       userRoutes        <- Resource.pure[F, UserRoutes[F]](new UserRoutes[F](userAlgebra))
       userLoginRoutes   <- Resource.pure[F, UserLoginRoutes[F]](new UserLoginRoutes[F](userAuthAlgebra))

--- a/modules/apis/user/src/main/scala/phms/api/user/UserLoginRoutes.scala
+++ b/modules/apis/user/src/main/scala/phms/api/user/UserLoginRoutes.scala
@@ -23,6 +23,8 @@ import phms.algebra.user._
 import phms._
 import phms.kernel._
 
+import scala.concurrent.duration._
+
 /** @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 26 Jun 2018
   */
@@ -30,6 +32,7 @@ final class UserLoginRoutes[F[_]](
   private val userAuthAlgebra: UserAuthAlgebra[F]
 )(implicit
   val F:                       Concurrent[F],
+  val temporal:                Temporal[F],
   val D:                       Defer[F],
 ) extends Http4sDsl[F] with UserRoutesJSON {
 
@@ -66,7 +69,9 @@ final class UserLoginRoutes[F[_]](
 
   private val loginRoutes: HttpRoutes[F] =
     HttpRoutes.of[F] { case req @ POST -> Root / "user" / "login" =>
-      Ok(findBasicAuth(req.headers).flatMap(logInWithUserNamePassword))
+      Ok(
+        findBasicAuth(req.headers).flatMap(logInWithUserNamePassword).fixedTime(2.seconds)
+      )
     }
 
   val routes: HttpRoutes[F] = loginRoutes

--- a/modules/apis/user/src/main/scala/phms/api/user/UserLoginRoutes.scala
+++ b/modules/apis/user/src/main/scala/phms/api/user/UserLoginRoutes.scala
@@ -36,10 +36,18 @@ final class UserLoginRoutes[F[_]](
   val D:                       Defer[F],
 ) extends Http4sDsl[F] with UserRoutesJSON {
 
-  /** User/password gets transimited in the ``Authorization``
-    * Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+  /** User/password gets transmitted in the ``Authorization`` header using
+    * the Basic authentication scheme. More details here:
+    *   [[https://tools.ietf.org/html/rfc7617#page-5 RFC-7617]]
     *
-    * base64Encoding($user:$password)
+    * header example
+    * {{{
+    *   Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+    * }}}
+    * structure of string after 'Basic'
+    * {{{
+    *   base64Encoding($user:$password)
+    * }}}
     */
   private def logInWithUserNamePassword(bc: BasicCredentials): F[AuthCtx] =
     for {

--- a/modules/apis/user/src/main/scala/phms/api/user/UserLoginRoutes.scala
+++ b/modules/apis/user/src/main/scala/phms/api/user/UserLoginRoutes.scala
@@ -70,7 +70,7 @@ final class UserLoginRoutes[F[_]](
   private val loginRoutes: HttpRoutes[F] =
     HttpRoutes.of[F] { case req @ POST -> Root / "user" / "login" =>
       Ok(
-        findBasicAuth(req.headers).flatMap(logInWithUserNamePassword).fixedTime(2.seconds)
+        findBasicAuth(req.headers).flatMap(logInWithUserNamePassword).minTime(2.seconds)
       )
     }
 

--- a/modules/utils/core/src/main/scala/phms/package.scala
+++ b/modules/utils/core/src/main/scala/phms/package.scala
@@ -19,7 +19,7 @@ import scala.{concurrent => sc}
 
 import cats.{effect => ce}
 import cats.syntax
-import cats.instances
+
 /** @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 05 Apr 2019
   */

--- a/modules/utils/testkit/src/test/scala/phms/TemporalOpsTest.scala
+++ b/modules/utils/testkit/src/test/scala/phms/TemporalOpsTest.scala
@@ -1,0 +1,22 @@
+package phms
+
+import munit._
+
+import scala.concurrent.duration._
+
+class TemporalOpsTest extends CatsEffectSuite {
+  test("fixed time in happy case") {
+    val x: IO[(FiniteDuration, Unit)] = IO.unit.fixedTime(50.millis).timed
+    x.map { case (dur, _) =>
+      assert(dur >= 50.millis)
+    }
+  }
+
+  test("fixed time in error case") {
+    val x: IO[(FiniteDuration, Attempt[Unit])] =
+      IO.raiseError[Unit](InvalidInputAnomaly("I failed")).attempt.fixedTime(50.millis).timed
+    x.map { case (dur, _) =>
+      assert(dur >= 50.millis)
+    }
+  }
+}

--- a/modules/utils/testkit/src/test/scala/phms/TemporalOpsTest.scala
+++ b/modules/utils/testkit/src/test/scala/phms/TemporalOpsTest.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 
 class TemporalOpsTest extends CatsEffectSuite {
   test("fixed time in happy case") {
-    val x: IO[(FiniteDuration, Unit)] = IO.unit.fixedTime(50.millis).timed
+    val x: IO[(FiniteDuration, Unit)] = IO.unit.minTime(50.millis).timed
     x.map { case (dur, _) =>
       assert(dur >= 50.millis)
     }
@@ -14,7 +14,7 @@ class TemporalOpsTest extends CatsEffectSuite {
 
   test("fixed time in error case") {
     val x: IO[(FiniteDuration, Attempt[Unit])] =
-      IO.raiseError[Unit](InvalidInputAnomaly("I failed")).attempt.fixedTime(50.millis).timed
+      IO.raiseError[Unit](InvalidInputAnomaly("I failed")).attempt.minTime(50.millis).timed
     x.map { case (dur, _) =>
       assert(dur >= 50.millis)
     }


### PR DESCRIPTION
Solve timing attack bug on login route, by making it execute in (at least) 2s regardless of correct/incorrect input.